### PR TITLE
Update runtime to 6.9, add x-checker-data

### DIFF
--- a/rocks.noise.qspeakers.yaml
+++ b/rocks.noise.qspeakers.yaml
@@ -1,6 +1,6 @@
 app-id: rocks.noise.qspeakers
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: qspeakers
 finish-args:
@@ -19,4 +19,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/be1/qspeakers.git
-        commit: "d0522e55483a7c8856b4cc6826514594134e5893"
+        tag: '1.8'
+        commit: d0522e55483a7c8856b4cc6826514594134e5893
+        x-checker-data:
+          type: git
+          tag-pattern: ^(\d.+)$


### PR DESCRIPTION
`x-checker-data` enables automatic updates and PRs for the module source