### PR TITLE
Update the runtime version from 6.9 to 6.10, and more

### DIFF
--- a/rocks.noise.qspeakers.yaml
+++ b/rocks.noise.qspeakers.yaml
@@ -1,8 +1,11 @@
 app-id: rocks.noise.qspeakers
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: qspeakers
+rename-desktop-file: qspeakers.desktop
+rename-icon: qspeakers
+copy-icon: true
 finish-args:
   # X11 + XShm access
   - --share=ipc
@@ -10,9 +13,6 @@ finish-args:
   # Wayland access
   - --socket=wayland
   - --device=dri
-rename-desktop-file: qspeakers.desktop
-rename-icon: qspeakers
-copy-icon: true
 modules:
   - name: qspeakers
     buildsystem: qmake


### PR DESCRIPTION
- Update the runtime version to 6.10
- Comply with Flathub styling guidelines

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide